### PR TITLE
Use correct case for library.properties name field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-Name=BH1750
+name=BH1750
 version=1.0.0
 author=Zorxx
 maintainer=Zorxx <zorxx@zorxx.com>


### PR DESCRIPTION
Incorrect capitalization of the `name` field in library.properties caused it to not be recognized by the Arduino IDE.

When a required field is missing the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format